### PR TITLE
Scim Active Flag Reset Fix

### DIFF
--- a/ScimCore/.project
+++ b/ScimCore/.project
@@ -6,7 +6,17 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.wst.common.project.facet.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.wst.validation.validationbuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
@@ -17,7 +27,10 @@
 		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.jem.workbench.JavaEMFNature</nature>
+		<nature>org.eclipse.wst.common.modulecore.ModuleCoreNature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
 	</natures>
 </projectDescription>

--- a/ScimCore/pom.xml
+++ b/ScimCore/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>com.github.RonanOD</groupId>
 	<artifactId>scimcore</artifactId>
 	<packaging>jar</packaging>
-	<version>0.4</version>
+	<version>0.5</version>
 	<name>SCIM Core</name>
 	<issueManagement>
 		<url>https://github.com/RonanOD/scimproxy</url>

--- a/ScimCore/src/main/java/info/simplecloud/core/User.java
+++ b/ScimCore/src/main/java/info/simplecloud/core/User.java
@@ -55,7 +55,7 @@ public class User extends Resource {
     private String                         locale;
     private String                         password;
     private String                         timezone;
-    private boolean                        active = true;
+    private Boolean                        active;
     private Name                           name;
     private List<MultiValuedType<String>>  phoneNumbers;
     private List<MultiValuedType<String>>  emails;
@@ -172,7 +172,11 @@ public class User extends Resource {
 
     @Attribute(name = "active", handler = BooleanHandler.class)
     public boolean getActive() {
-        return active;
+        if (active == null) {
+          return true;
+        } else {
+          return active.booleanValue();
+        }
     }
 
     @Attribute(name = "name", handler = ComplexHandler.class, type = Name.class)
@@ -266,7 +270,7 @@ public class User extends Resource {
     }
 
     public void setActive(boolean active) {
-        this.active = active;
+        this.active = Boolean.valueOf(active);
     }
 
     public void setName(Name name) {


### PR DESCRIPTION
The active flag was being reset to true when constructor was called with a JSON String containing active:false. Solution is to use Boolean object as null to depict the unset state.
